### PR TITLE
Fix CI: test環境のqueue DB設定を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          POSTGRES_PASSWORD: postgres
           REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare && bundle exec rspec
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -41,12 +41,21 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: myapp_test
-  username: postgres
-  password: password
-  host: localhost
-  port: 5432
+  primary:
+    <<: *default
+    database: myapp_test
+    username: postgres
+    password: <%= ENV.fetch("POSTGRES_PASSWORD", "password") %>
+    host: localhost
+    port: 5432
+  queue:
+    <<: *default
+    database: myapp_test_queue
+    username: postgres
+    password: <%= ENV.fetch("POSTGRES_PASSWORD", "password") %>
+    host: localhost
+    port: 5432
+    migrations_paths: db/queue_migrate
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
前回のPR #8 でmulti-db化したが、test環境のdatabase.ymlにqueue DBが未設定だったためCIが落ちた。

- database.yml: test環境にqueue DB追加 + POSTGRES_PASSWORDで認証情報を外部化
- ci.yml: POSTGRES_PASSWORD=postgres を追加