### PR TITLE
Fix: production.rbのqueue_adapterをsolid_queueに修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :sidekiq
+  config.active_job.queue_adapter = :solid_queue
 
   # Action Cable (WebSocket) configuration
   config.action_cable.url = "wss://#{ENV['APP_DOMAIN']}/cable"


### PR DESCRIPTION
`config/environments/production.rb` に `queue_adapter = :sidekiq` が残っており、`application.rb` の `:solid_queue` 設定を上書きしていた。本番環境でジョブが常に Sidekiq に積まれ、処理されない状態だった根本原因。