### PR TITLE
feat: 管理画面にDBスナップショット取得ボタンを追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,6 +91,35 @@ docker compose up
 - DB: PostgreSQL 16（`postgres:password@localhost:5432`）
 - Redis: localhost:6379
 
+## DBスナップショット（本番DB情報のJSON同期）
+
+本番DBのデータをJSON形式でエクスポートし、`db-snapshots` ブランチに保存する仕組みがあります。
+
+### 構成
+
+| ファイル | 役割 |
+|---|---|
+| `lib/tasks/db_snapshot.rake` | `bin/rails db:snapshot` タスク（JSONをstdoutへ出力） |
+| `.github/workflows/db_snapshot.yml` | VPS上でタスクを実行し `db-snapshots` ブランチへコミット |
+
+### 実行方法
+
+- **管理画面**: Admin Dashboard ナビの「DBスナップショット取得」ボタン
+  - `GITHUB_DEPLOY_TOKEN` 環境変数（GitHub PAT / workflow権限）が必要
+- **GitHub Actions UI**: Actions → "DB Snapshot for Claude" → Run workflow
+
+### スナップショットの内容
+
+- 全テーブルのレコード件数
+- センシティブカラムを除いた各モデルの直近データ（users, ai_users, ai_profiles, ai_posts 等）
+- 除外カラム: `encrypted_password`, `reset_password_token`, `stripe_customer_id`, `stripe_subscription_id`
+
+### 注意
+
+- 出力先ブランチは `db-snapshots`（orphanブランチ）
+- ファイル名は `db_snapshot.json`（毎回上書き）
+- 実行のたびに `snapshot: YYYY-MM-DD HH:MM UTC` でコミットされる
+
 ## PR作成時のチェックリスト
 
 1. `bin/rubocop` でエラーがないことを確認

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -72,4 +72,34 @@ class Admin::DashboardController < Admin::BaseController
   rescue => e
     redirect_to admin_root_path, alert: "エラー: #{e.message}"
   end
+
+  def trigger_db_snapshot
+    token = ENV["GITHUB_DEPLOY_TOKEN"]
+    unless token.present?
+      redirect_to admin_root_path, alert: "GITHUB_DEPLOY_TOKEN が設定されていません"
+      return
+    end
+
+    uri = URI("https://api.github.com/repos/kawauso29/myapp/actions/workflows/db_snapshot.yml/dispatches")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.open_timeout = 10
+    http.read_timeout = 15
+
+    req = Net::HTTP::Post.new(uri.request_uri)
+    req["Authorization"] = "Bearer #{token}"
+    req["Accept"] = "application/vnd.github+json"
+    req["X-GitHub-Api-Version"] = "2022-11-28"
+    req["Content-Type"] = "application/json"
+    req.body = { ref: "main" }.to_json
+
+    res = http.request(req)
+    if res.code == "204"
+      redirect_to admin_root_path, notice: "DBスナップショットを開始しました。db-snapshots ブランチに保存されます。"
+    else
+      redirect_to admin_root_path, alert: "スナップショット起動失敗 (#{res.code}): #{res.body}"
+    end
+  rescue => e
+    redirect_to admin_root_path, alert: "エラー: #{e.message}"
+  end
 end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -159,6 +159,9 @@
     <%= form_with url: admin_sync_env_path, method: :post, style: "margin-left: auto;" do |f| %>
       <%= f.submit "環境変数を同期", class: "btn btn-success btn-sm" %>
     <% end %>
+    <%= form_with url: admin_trigger_db_snapshot_path, method: :post do |f| %>
+      <%= f.submit "DBスナップショット取得", class: "btn btn-sm", style: "background:#4a5568; color:#e2e8f0;" %>
+    <% end %>
   </nav>
   <main>
     <% if flash[:notice] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   namespace :admin do
     root to: "dashboard#index"
     post "sync_env", to: "dashboard#sync_env"
+    post "trigger_db_snapshot", to: "dashboard#trigger_db_snapshot"
 
     resources :ai_sns, only: [ :index ] do
       collection do


### PR DESCRIPTION
## Summary

- Admin Dashboard のナビバーに「DBスナップショット取得」ボタンを追加
- ボタン押下で `db_snapshot.yml` ワークフローを `workflow_dispatch` 起動（既存の「環境変数を同期」と同じパターン）
- VPS上で `bin/rails db:snapshot` を実行し、結果を `db-snapshots` ブランチの `db_snapshot.json` に保存
- `copilot-instructions.md` にDBスナップショットの仕様・使い方を追記

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `config/routes.rb` | `POST /admin/trigger_db_snapshot` ルートを追加 |
| `app/controllers/admin/dashboard_controller.rb` | `trigger_db_snapshot` アクションを追加 |
| `app/views/layouts/admin.html.erb` | ナビに「DBスナップショット取得」ボタンを追加 |
| `.github/copilot-instructions.md` | DBスナップショット仕様を追記 |

## 前提条件

- `GITHUB_DEPLOY_TOKEN` 環境変数（GitHub PAT、`workflow` スコープ）がVPSの `.env` に設定済みであること

## Test plan

- [ ] Admin 管理画面のナビに「DBスナップショット取得」ボタンが表示される
- [ ] ボタン押下後、GitHub Actions の "DB Snapshot for Claude" ワークフローが起動する
- [ ] `db-snapshots` ブランチに `db_snapshot.json` がコミットされる
- [ ] `GITHUB_DEPLOY_TOKEN` 未設定時にアラートが表示される

https://claude.ai/code/session_01Y3xCRTyYsBmfG9BdDmqDhG