### PR TITLE
CIパス後にPRを直接マージするよう auto_merge.yml を書き直し

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,86 +1,103 @@
-name: Enable Auto Merge
+name: Auto Merge on CI Pass
 
 on:
   pull_request_target:
     types:
       - opened
-      - labeled
-      - synchronize
-      - reopened
       - ready_for_review
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
+  # PRが開かれたときに automerge ラベルを付与する
   add_automerge_label:
-    if: ${{ github.event.action == 'opened' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: >-
+      ${{ github.event_name == 'pull_request_target' &&
+          !github.event.pull_request.draft &&
+          github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
-      - name: Add automerge label
+      - name: Ensure automerge label exists and add to PR
         uses: actions/github-script@v7
         with:
           script: |
+            // ラベルが存在しない場合は作成する
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'automerge'
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'automerge',
+                  color: '0075ca',
+                  description: 'Auto-merge when CI passes'
+                });
+                core.info("Created 'automerge' label");
+              }
+            }
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels: ["automerge"],
-            })
-            core.info(`Added 'automerge' label to PR #${context.payload.pull_request.number}`)
+              labels: ['automerge']
+            });
+            core.info(`Added 'automerge' label to PR #${context.payload.pull_request.number}`);
 
-  enable_auto_merge:
-    if: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'automerge') && github.event.pull_request.head.repo.full_name == github.repository }}
+  # CI が通ったら automerge ラベル付きの PR を直接マージする
+  merge_on_ci_pass:
+    if: >-
+      ${{ github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge for labeled PR
+      - name: Merge PR after CI pass
         uses: actions/github-script@v7
         with:
           script: |
-            if (!context.payload.pull_request) {
-              throw new Error("Pull request context is missing")
+            const headSha = context.payload.workflow_run.head_sha;
+            const headBranch = context.payload.workflow_run.head_branch;
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${headBranch}`
+            });
+
+            const pr = prs.find(p => p.head.sha === headSha);
+            if (!pr) {
+              core.info('No open PR found for this CI run');
+              return;
             }
 
-            const pullRequestId = context.payload.pull_request.node_id
+            const hasLabel = pr.labels.some(l => l.name === 'automerge');
+            if (!hasLabel) {
+              core.info(`PR #${pr.number}: automerge label not found, skipping`);
+              return;
+            }
 
+            core.info(`CI passed for PR #${pr.number}, merging...`);
             try {
-              const current = await github.graphql(
-                `
-                  query($pullRequestId: ID!) {
-                    node(id: $pullRequestId) {
-                      ... on PullRequest {
-                        number
-                        autoMergeRequest {
-                          enabledAt
-                        }
-                      }
-                    }
-                  }
-                `,
-                { pullRequestId }
-              )
-
-              if (current?.node?.autoMergeRequest) {
-                core.info(`Auto-merge is already enabled for PR #${context.payload.pull_request.number}`)
-                return
-              }
-
-              await github.graphql(
-                `
-                  mutation($pullRequestId: ID!) {
-                    enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: SQUASH }) {
-                      pullRequest {
-                        number
-                      }
-                    }
-                  }
-                `,
-                { pullRequestId }
-              )
-              core.info(`Auto-merge enabled for PR #${context.payload.pull_request.number}`)
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                merge_method: 'squash'
+              });
+              core.info(`Successfully merged PR #${pr.number}`);
             } catch (error) {
-              const message = String(error?.message || "Unknown error occurred")
-              core.error(`Failed to enable auto-merge for PR #${context.payload.pull_request.number}: ${message}`)
-              throw error
+              core.error(`Failed to merge PR #${pr.number}: ${error.message}`);
+              throw error;
             }


### PR DESCRIPTION
旧実装はGitHubビルトインのauto-merge（GraphQL mutation）を使っており、 リポジトリ設定の「Allow auto-merge」有効化とブランチ保護ルールが必須だった。

新実装はworkflow_runトリガーでCI完了を検知し、
automergeラベル付きのPRをREST APIで直接マージする方式に変更。
リポジトリ設定に依存せず確実に動作する。

https://claude.ai/code/session_01WJGqQ5b3pBjVKEZMfnsJct

## 変更内容

<!-- このPRで何を変更したか簡潔に説明してください -->

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] CI/デプロイ設定変更
- [ ] その他

## 確認事項

- [ ] ローカルで動作確認済み
- [ ] `bundle exec rspec` でテストが通ることを確認済み
- [ ] `bin/rubocop` でLintエラーがないことを確認済み

## 再発防止ルール（CI失敗を修正した場合）

<!-- CI失敗を修正したPRの場合のみ記入。該当しない場合はスキップ可。 -->

- 失敗したジョブ: <!-- lint / test / scan_ruby など -->
- 原因: <!-- 例: Time.now を使っていた（Rails/TimeZone違反） -->
- 再発防止策: <!-- 例: CLAUDE.md の「CIエラーの原因になったこと」に追記済み -->

**CI失敗修正PRの場合のみチェック（それ以外はスキップ）:**
- [ ] `CLAUDE.md` の「CIエラーの原因になったこと」に原因と対策を追記した
- [ ] 今後同じ問題が起きないよう、コーディングルールを更新した（または不要と判断した）
